### PR TITLE
Update README.md (Full Repo Name)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <table align=center><td>
 
 ```yml
-- uses: yusancky/setup-typst@v3
+- uses: typst-community/setup-typst@v3
 - run: typst compile paper.typ paper.pdf
 ```
 
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: yusancky/setup-typst@v3
+      - uses: typst-community/setup-typst@v3
       # Now Typst is installed!
       - run: typst compile paper.typ paper.pdf
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
This fixes the README to use the correct full repo name after the transfer to typst-community.