### PR TITLE
Allow prerelease Typst installing

### DIFF
--- a/.github/workflows/publish-action.yml
+++ b/.github/workflows/publish-action.yml
@@ -1,4 +1,4 @@
-name: publish-action
+name: Publish action
 on:
   release:
     types: released

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -15,6 +15,7 @@ on:
       - LICENSE
       - .github/**
       - "!.github/workflows/test-action.yml"
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2024 yusancky
+Copyright (c) 2023-2025 yusancky
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align=center>
+  <b>English</b> | <a href="https://github.com/typst-community/setup-typst/blob/main/README_zh-Hans-CN.md" hreflang="zh-Hans-CN" lang="zh-Hans-CN">简体中文</a>
+</p>
+
 # Setup Typst
 
 This action provides the following functionality for GitHub Actions users:
@@ -8,7 +12,7 @@ This action provides the following functionality for GitHub Actions users:
 <table align=center><td>
 
 ```yaml
-- uses: typst-community/setup-typst@v3
+- uses: typst-community/setup-typst@v4
 - run: typst compile paper.typ paper.pdf
 ```
 
@@ -16,8 +20,8 @@ This action provides the following functionality for GitHub Actions users:
 
 ## Usage
 
-![GitHub Actions](https://img.shields.io/static/v1?style=for-the-badge&message=GitHub+Actions&color=2088FF&logo=GitHub+Actions&logoColor=FFFFFF&label=)
-![GitHub](https://img.shields.io/static/v1?style=for-the-badge&message=GitHub&color=181717&logo=GitHub&logoColor=FFFFFF&label=)
+[![GitHub Actions](https://img.shields.io/static/v1?style=for-the-badge&message=GitHub+Actions&color=2088FF&logo=GitHub+Actions&logoColor=FFFFFF&label=)](https://github.com/marketplace/actions/setup-typst)
+[![GitHub](https://img.shields.io/static/v1?style=for-the-badge&message=GitHub&color=181717&logo=GitHub&logoColor=FFFFFF&label=)](https://github.com/typst-community/setup-typst)
 
 ### Basic usage
 
@@ -29,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: typst-community/setup-typst@v3
+      - uses: typst-community/setup-typst@v4
         with:
           cache-dependency-path: requirements.typ
       # Now Typst is installed and packages will be cached!
@@ -38,28 +42,22 @@ jobs:
 
 ### Inputs
 
-- **`typst-token`:** The GitHub token to use when pulling versions from
-  [typst/typst]. By default this should cover all cases. You shouldn't have to
-  touch this setting.
-- **`typst-version`:** The version of Typst to install. This can be an exact
-  version like `0.10.0` or a semver range like `0.10` or `0.x`. You can also
-  specify `latest` to always use the latest version. The default is `latest`.
-- **`cache-dependency-path`:** Used to specify the path to dependency file.
-  Supports a Typst file with lines of `import` keyword.
+- **`typst-version`:** Version range or exact version of Typst to use, using SemVer's version range syntax. Uses the latest version if unset.
+- **`allow-prereleases`:** When `true`, a version range including `latest` passed to `typst-version` input will match prerelease versions.
+- **`cache-dependency-path`:** Used to specify the path to dependency file. Supports a Typst file with lines of `import` keyword.
+- **`token`:** The token used to authenticate when fetching Typst distributions from [typst/typst]. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
 
 ### Outputs
 
-- **`typst-version`:** The version of Typst that was installed. This will be
-  something like `0.10.0` or similar.
-- **`cache-hit`:** Whether or not Typst was restored from the runner's cache or
-  download anew.
+- **`typst-version`:** The installed Typst version. Useful when given a version range as input.
+- **`cache-hit`:** A boolean value to indicate a cache entry was found.
 
 ### Custom combinations
 
 #### Uploading workflow artifact
 
 ```yaml
-- uses: typst-community/setup-typst@v3
+- uses: typst-community/setup-typst@v4
   with:
     cache-dependency-path: requirements.typ
 - run: typst compile paper.typ paper.pdf
@@ -71,14 +69,12 @@ jobs:
 
 #### Expanding font support with Fontist
 
-If your tasks require extending beyond the set of fonts in GitHub Actions runner,
-you can employ the Fontist to facilitate custom font installations. Here's an
-example showcasing how to use [fontist/setup-fontist] to add new fonts:
+If your tasks require extending beyond the set of fonts in GitHub Actions runner, you can employ the Fontist to facilitate custom font installations. Here's an example showcasing how to use [fontist/setup-fontist] to add new fonts:
 
 ```yaml
 - uses: fontist/setup-fontist@v2
 - run: fontist install "Fira Code"
-- uses: typst-community/setup-typst@v3
+- uses: typst-community/setup-typst@v4
   with:
     cache-dependency-path: requirements.typ
 - run: typst compile paper.typ paper.pdf --font-path ~/.fontist/fonts
@@ -90,8 +86,8 @@ example showcasing how to use [fontist/setup-fontist] to add new fonts:
 
 **How do I test my changes?**
 
-Open a draft Pull Request and some magic GitHub Actions will run to test the
-action.
+Open a Pull Request and some magic GitHub Actions will run to test the action.
 
 [Typst]: https://typst.app/
 [typst/typst]: https://github.com/typst/typst
+[fontist/setup-fontist]: https://github.com/fontist/setup-fontist

--- a/README_zh-Hans-CN.md
+++ b/README_zh-Hans-CN.md
@@ -6,13 +6,13 @@
 
 此操作为 GitHub Actions 用户提供以下功能：
 
-- 安装给定版本的 Typst 并将其加入 PATH
-- 可选地将 [第三方包](https://github.com/typst/packages) 依赖缓存
+- 安装指定版本的 Typst
+- （可选）缓存依赖的 [第三方包](https://github.com/typst/packages)
 
 <table align=center><td>
 
 ```yaml
-- uses: typst-community/setup-typst@v3
+- uses: typst-community/setup-typst@v4
 - run: typst compile paper.typ paper.pdf
 ```
 
@@ -20,8 +20,8 @@
 
 ## 用法
 
-![GitHub Actions](https://img.shields.io/static/v1?style=for-the-badge&message=GitHub+Actions&color=2088FF&logo=GitHub+Actions&logoColor=FFFFFF&label=)
-![GitHub](https://img.shields.io/static/v1?style=for-the-badge&message=GitHub&color=181717&logo=GitHub&logoColor=FFFFFF&label=)
+[![GitHub Actions](https://img.shields.io/static/v1?style=for-the-badge&message=GitHub+Actions&color=2088FF&logo=GitHub+Actions&logoColor=FFFFFF&label=)](https://github.com/marketplace/actions/setup-typst)
+[![GitHub](https://img.shields.io/static/v1?style=for-the-badge&message=GitHub&color=181717&logo=GitHub&logoColor=FFFFFF&label=)](https://github.com/typst-community/setup-typst)
 
 ### 基本用法
 
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: typst-community/setup-typst@v3
+      - uses: typst-community/setup-typst@v4
         with:
           cache-dependency-path: requirements.typ
       # Typst 被安装，且第三方包将被缓存！
@@ -42,28 +42,22 @@ jobs:
 
 ### 输入
 
-- **`typst-token`:** 当从 [typst/typst] 拉取版本时使用的 GitHub 令牌。默认情况下，这应
-  该涵盖全部情况。你通常无需修改此项。
-
-- **`typst-version`:** 需要安装的 Typst 的版本。它可以是一个确定的版本号如 `0.10.0` 或
-  语义化版本号如 `0.10` 和 `0.x`。你也可以使用 `latest` 使用最新版本的 Typst。默认值为
-  `latest`。
-
-- **`cache-dependency-path`:** 第三方包依赖列表文件的文件名。该文件应该是一个含有
-  `import` 关键字的 Typst 文件。
+- **`typst-version`:** 使用的 Typst 版本范围或确切版本，采用 SemVer 语义化版本范围语法。默认使用最新版本。
+- **`allow-prereleases`:** 当设置为 `true` 时，传递给 `typst-version` 的版本范围（包含 `latest`）将匹配预发布版本。
+- **`cache-dependency-path`:** 依赖的第三方包列表文件的文件名。该文件应该是一个含有 `import` 关键字的 Typst 文件。
+- **`token`:** 当从 [typst/typst] 拉取版本时使用的 GitHub 令牌。当在 github.com 上运行操作时，使用默认值；当在 GitHub Enterprise Server（GHES）上运行，可以传递一个 github.com 的个人访问令牌规避速率限制问题。
 
 ### 输出
 
-- **`typst-version`:** 安装的 Typst 的版本。它的格式应该类似 `0.10.0`。
-
-- **`cache-hit`:** Typst 是否存缓存下载。
+- **`typst-version`:** 安装的 Typst 的确切版本。在输入时给定版本范围时可能有用。
+- **`cache-hit`:** 一个表示是否找到 Typst 缓存的布尔值。
 
 ### 自定义组合
 
-#### 上传工作流构件
+#### 上传到工作流工件
 
 ```yaml
-- uses: typst-community/setup-typst@v3
+- uses: typst-community/setup-typst@v4
   with:
     cache-dependency-path: requirements.typ
 - run: typst compile paper.typ paper.pdf
@@ -75,13 +69,12 @@ jobs:
 
 #### 使用 Fontist 拓展字体支持
 
-如需为 GitHub Actions 运行器拓展字体库，可使用 Fontist 进行自定义字体安装。以下是使用
-[fontist/setup-fontist] 添加新字体的范例：
+如需为 GitHub Actions 运行器拓展字体库，可使用 Fontist 进行自定义字体安装。以下是使用 [fontist/setup-fontist] 添加新字体的范例：
 
 ```yaml
 - uses: fontist/setup-fontist@v2
 - run: fontist install "Fira Code"
-- uses: typst-community/setup-typst@v3
+- uses: typst-community/setup-typst@v4
   with:
     cache-dependency-path: requirements.typ
 - run: typst compile paper.typ paper.pdf --font-path ~/.fontist/fonts
@@ -93,7 +86,8 @@ jobs:
 
 **我应该如何测试我的贡献？**
 
-开启一个草稿拉取请求，GitHub Actions 测试项将在被管理员的许可后运行。
+开启拉取请求后，GitHub Actions 测试项将在管理员的许可后运行。
 
 [Typst]: https://typst.app/
 [typst/typst]: https://github.com/typst/typst
+[fontist/setup-fontist]: https://github.com/fontist/setup-fontist

--- a/action.yml
+++ b/action.yml
@@ -6,31 +6,24 @@ branding:
   color: white
 
 inputs:
-  typst-token:
-    description: >
-      The GitHub token to use when pulling versions from typst/typst. By default
-      this should cover all cases. You shouldn't have to touch this setting.
-    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
   typst-version:
-    description: >
-      The version of Typst to install. This can be an exact version like '0.10.0'
-      or a semver range like '0.10' or '0.x'. You can also specify 'latest' to
-      always use the latest version. The default is 'latest'.
+    description: "Version range or exact version of Typst to use, using SemVer's version range syntax. Uses the latest version if unset."
     default: latest
+  allow-prereleases:
+    description: "When 'true', a version range including 'latest' passed to 'typst-version' input will match prerelease versions."
+    default: false
   cache-dependency-path:
-    description: >
-      Used to specify the path to dependency file. Supports a Typst file with
-      lines of 'import' keyword.
+    description: "Used to specify the path to dependency file. Supports a Typst file with lines of 'import' keyword."
     required: false
+  token:
+    description: "The token used to authenticate when fetching Typst distributions from typst/typst. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting."
+    default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
 
 outputs:
   typst-version:
-    description: >
-      The version of Typst that was installed. This will be something like
-      '0.10.0' or similar.
+    description: "The installed Typst version. Useful when given a version range as input."
   cache-hit:
-    description: >
-      Whether or not Typst was restored from the runner's cache or download anew.
+    description: "A boolean value to indicate a cache entry was found."
 
 runs:
   using: node20

--- a/test/test.typ
+++ b/test/test.typ
@@ -1,8 +1,3 @@
 #import "@preview/example:0.1.0": *
 
-= Introduction
-In this report, we will explore the
-various factors that influence _fluid
-dynamics_ in glaciers and how they
-contribute to the formation and
-behavior of these natural structures.
+#lorem(50)


### PR DESCRIPTION
1. **Introduced the `allow-prereleases` input option** to allow users to install prerelease versions of Typst. By default, prereleases are not installed.
    - I've given it a brief test: When `latest` is specified, the action uses the latest stable version (`0.12.0`) if `allow-prereleases` is disabled, and the latest prerelease version (`0.13.0 rc 1`) if enabled. Judging from the results, I am sure that there are no problems.
2. **[Breaking Change] Renamed `typst-token` to `token`** to align with GitHub's official actions.
    - This may affect users using GitHub Enterprise Server (GHES).
3. **[Documentation]** Updated `README.md` files in both English and Simplified Chinese.

This PR aims to enhance flexibility while maintaining compatibility for most users. Feedback is appreciated!