### PR TITLE
Improve token handling

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -20,12 +20,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  test-action:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+  build:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -34,6 +30,23 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: action-dist
+          path: ./dist
+  test:
+    runs-on: ${{ matrix.os }}
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: action-dist
+          path: ./dist
       - uses: ./
         with:
           cache-dependency-path: test/requirements.typ

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@actions/github": "^6.0.0",
         "@actions/glob": "^0.5.0",
         "@actions/tool-cache": "^2.0.1",
-        "@octokit/auth-unauthenticated": "^5.0.1",
         "@vercel/ncc": "^0.38.1",
         "semver": "^7.5.4"
       },
@@ -437,19 +436,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
       "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
       "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@octokit/auth-unauthenticated": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-5.0.1.tgz",
-      "integrity": "sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/request-error": "^5.0.0",
-        "@octokit/types": "^12.0.0"
-      },
       "engines": {
         "node": ">= 18"
       }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@actions/github": "^6.0.0",
     "@actions/glob": "^0.5.0",
     "@actions/tool-cache": "^2.0.1",
-    "@octokit/auth-unauthenticated": "^5.0.1",
     "@vercel/ncc": "^0.38.1",
     "semver": "^7.5.4"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,29 +6,39 @@ import * as github from "@actions/github";
 import * as glob from "@actions/glob";
 import * as tc from "@actions/tool-cache";
 import fs from "fs";
-import { createUnauthenticatedAuth } from "@octokit/auth-unauthenticated";
 import * as os from "os";
 import { join } from "node:path";
 import { exit } from "process";
 import * as semver from "semver";
 
-const octokit = core.getInput("token")
-  ? github.getOctokit(core.getInput("token"))
-  : github.getOctokit(undefined!, {
-      authStrategy: createUnauthenticatedAuth,
-      auth: { reason: "no 'token' input" },
-    });
-
+const token = core.getInput("token");
+const octokit = token
+  ? github.getOctokit(token, { baseUrl: "https://api.github.com" })
+  : null;
 const repoSet = {
   owner: "typst",
   repo: "typst",
 };
 let version = core.getInput("typst-version");
 const allowPrereleases = core.getBooleanInput("allow-prereleases");
-const releases = await octokit.paginate(
-  octokit.rest.repos.listReleases,
-  repoSet,
-);
+
+let releases: any[] = [];
+
+if (octokit) {
+  releases = await octokit.paginate(octokit.rest.repos.listReleases, repoSet);
+} else {
+  const releasesUrl = `https://api.github.com/repos/typst/typst/releases`;
+  const releasesResponse = await tc.downloadTool(releasesUrl);
+  try {
+    releases = JSON.parse(fs.readFileSync(releasesResponse, "utf8"));
+  } catch (error) {
+    core.setFailed(
+      `Failed to parse releases: ${(error as Error).message}. This could be caused by API rate limit exceeded.`
+    );
+    process.exit(1);
+  }
+}
+
 const versions = releases
   .map((release) => release.tag_name.slice(1))
   .filter((v) => semver.valid(v));
@@ -36,11 +46,12 @@ version = semver.maxSatisfying(versions, version === "latest" ? "*" : version, {
   includePrerelease: allowPrereleases ? true : false,
 })!;
 core.debug(`Resolved version: v${version}`);
-if (!version)
+if (!version) {
   core.setFailed(
-    `Typst ${core.getInput("typst-version")} could not be resolved`,
+    `Typst ${core.getInput("typst-version")} could not be resolved.`
   );
-
+  process.exit(1);
+}
 let found = tc.find("typst", version);
 core.setOutput("cache-hit", !!found);
 if (!found) {
@@ -60,7 +71,7 @@ if (!found) {
   const folder = `typst-${target}`;
   const file = `${folder}${archiveExt}`;
   found = await tc.downloadTool(
-    `https://github.com/typst/typst/releases/download/v${version}/${file}`,
+    `https://github.com/typst/typst/releases/download/v${version}/${file}`
   );
   if (file.endsWith(".zip")) {
     found = await tc.extractZip(found);
@@ -83,7 +94,7 @@ if (cachePackage) {
         join(
           process.env.XDG_CACHE_HOME ||
             (os.homedir() ? join(os.homedir(), ".cache") : undefined)!,
-          "typst/packages",
+          "typst/packages"
         ),
       darwin: () => join(process.env.HOME!, "Library/Caches", "typst/packages"),
       win32: () => join(process.env.LOCALAPPDATA!, "typst/packages"),
@@ -98,9 +109,8 @@ if (cachePackage) {
       let cacheId = 0;
       try {
         cacheId = await cache.saveCache([cacheDir], primaryKey);
-      } catch (err) {
-        const message = (err as Error).message;
-        core.warning(message);
+      } catch (error) {
+        core.warning(`Failed to save cache: ${(error as Error).message}.`);
       }
       if (cacheId != -1) {
         core.info(`✅ Cache saved with the key: ${primaryKey}`);
@@ -108,8 +118,6 @@ if (cachePackage) {
       exit(0);
     }
   } else {
-    core.warning(
-      `${cachePackage} was not found. Packages will not be cached.`,
-    );
+    core.warning(`${cachePackage} is not found. Packages will not be cached.`);
   }
 }


### PR DESCRIPTION
Closes #29

This PR deprecates the `createUnauthenticatedAuth` method in the `@octokit/auth-unauthenticated` library.

In environments such as the GitHub Enterprise Server (GHES), `octokit` instances will be set to `null` if the input `token` is not explicitly provided. To improve environmental resilience and functional stability, the `downloadTool` method in the `@actions/tool-cache` library will be utilized when `octokit` is `null` to securely call the GitHub API over the HTTPS protocol to ensure accurate access to project release information.

The goal of this adjustment is to ensure smooth access to the necessary release information in different scenarios, especially in enterprise environments, so that our tool can efficiently support subsequent processes and improve overall compatibility and security.