### PR TITLE
Warn when typst version inputs are ignored

### DIFF
--- a/src/config-parser.ts
+++ b/src/config-parser.ts
@@ -37,6 +37,38 @@ const EXTENSION_TO_FORMAT: Record<string, SupportedFormat> = {
   ".hcl": "hcl",
 };
 
+const INPUT_FORMATS: SupportedFormat[] = [
+  "json",
+  "hjson",
+  "yaml",
+  "toml",
+  "xml",
+  "ini",
+  "hcl",
+];
+
+function joinInputNames(inputNames: string[]): string {
+  if (inputNames.length === 0) {
+    return "";
+  }
+  if (inputNames.length === 1) {
+    return inputNames[0];
+  }
+  return `${inputNames.slice(0, -1).join(", ")} and ${inputNames[inputNames.length - 1]}`;
+}
+
+function warnIgnoredInputs(
+  usedInputName: string,
+  ignoredInputNames: string[],
+) {
+  if (ignoredInputNames.length === 0) {
+    return;
+  }
+  core.warning(
+    `The ${usedInputName} input will be used. If it cannot be parsed, the action will fail. The ${joinInputNames(ignoredInputNames)} ${ignoredInputNames.length === 1 ? "input" : "inputs"} will be ignored.`,
+  );
+}
+
 /**
  * Parses a string in any supported configuration format into a JSON-compatible JavaScript object.
  *
@@ -117,6 +149,25 @@ export async function parseInputToObject(
   baseKey: string,
 ): Promise<Record<string, unknown> | undefined> {
   const fileInput = core.getInput(`${baseKey}-file`);
+  const formatInputs = INPUT_FORMATS.flatMap((format) => {
+    const inputName = `${baseKey}-${format}`;
+    const content = core.getInput(inputName);
+    return content ? [{ inputName, format, content }] : [];
+  });
+
+  if (fileInput && formatInputs.length > 0) {
+    warnIgnoredInputs(
+      `${baseKey}-file`,
+      formatInputs.map((input) => input.inputName),
+    );
+  } else if (!fileInput && formatInputs.length > 1) {
+    const [usedInput, ...ignoredInputs] = formatInputs;
+    warnIgnoredInputs(
+      usedInput.inputName,
+      ignoredInputs.map((input) => input.inputName),
+    );
+  }
+
   if (fileInput) {
     try {
       return await parseConfigFileToObject(fileInput);
@@ -126,25 +177,11 @@ export async function parseInputToObject(
       );
     }
   }
-  const formats: SupportedFormat[] = [
-    "json",
-    "hjson",
-    "yaml",
-    "toml",
-    "xml",
-    "ini",
-    "hcl",
-  ];
-  for (const format of formats) {
-    const content = core.getInput(`${baseKey}-${format}`);
-    if (content) {
-      try {
-        return parseToJsonObject(content, format);
-      } catch (err) {
-        throw new Error(
-          `Failed to parse ${baseKey}-${format}: ${(err as Error).message}`,
-        );
-      }
+  for (const { format, content, inputName } of formatInputs) {
+    try {
+      return parseToJsonObject(content, format);
+    } catch (err) {
+      throw new Error(`Failed to parse ${inputName}: ${(err as Error).message}`);
     }
   }
   return undefined;

--- a/src/main.ts
+++ b/src/main.ts
@@ -236,9 +236,16 @@ const repoSet = {
   repo: "typst",
 };
 const releases = await listReleases(octokit, repoSet);
+const typstVersion = core.getInput("typst-version");
+const executableName = core.getInput("executable-name");
 
 const versionsMap = (await parseInputToObject("typst-versions")) as any;
 if (versionsMap) {
+  if (typstVersion !== "latest" || executableName !== "typst") {
+    core.warning(
+      "The typst-version and executable-name inputs will be ignored when any typst-versions-* input is set.",
+    );
+  }
   await ensureMultipleTypstInstalled(versionsMap, releases);
 } else {
   const versionsMapStr = core.getInput("typst-versions-map");
@@ -257,14 +264,12 @@ if (versionsMap) {
     }
     await ensureMultipleTypstInstalled(versionsMap, releases);
   } else {
-    const version = core.getInput("typst-version");
     const allowPrereleases = core.getBooleanInput("allow-prereleases");
     const versionExact = await getExactVersion(
       releases,
-      version,
+      typstVersion,
       allowPrereleases,
     );
-    const executableName = core.getInput("executable-name");
     await ensureTypstInstalled(versionExact, executableName);
   }
 }


### PR DESCRIPTION
When `typst-versions-*` is provided, `typst-version` and `executable-name` are ignored today without any signal. This change makes that override explicit so users can see when their single-version inputs are being bypassed.

- **Input conflict warning**
  - Emit a `core.warning` when `typst-versions-*` is set alongside non-default `typst-version` / `executable-name` inputs.
  - Keep the message consistent with existing warning style in the action.

- **Multiple `typst-versions-*` inputs warning**
  - Emit a `core.warning` when more than one `typst-versions-*` input is set.
  - Clearly state which `typst-versions-*` input is used and which ones are ignored.

- **Preserve existing behavior**
  - Multi-version installation still takes precedence.
  - Default single-version inputs remain unchanged when no `typst-versions-*` input is present.

```yaml
with:
  typst-versions-file: config.json
  typst-version: v0.14
  executable-name: typst-latest
```

With this configuration, the action now warns that `typst-version` and `executable-name` are ignored.